### PR TITLE
Update archive.py

### DIFF
--- a/happypanda/server/core/archive.py
+++ b/happypanda/server/core/archive.py
@@ -54,7 +54,15 @@ class ArchiveFile():
             raise exceptions.CreateArchiveError(filepath, e)
 
     def namelist(self):
-        filelist = self.archive.namelist()
+        filelist= []
+        for x in self.archive.namelist():
+            if x.endswith('/'):
+                filelist.append(x)
+            else:
+                filelist.append(x[:(x.rindex('/')+1)])
+                filelist.append(x)
+        seen = set()
+        filelist = [x for x in filelist if x not in seen and not seen.add(x)]
         return filelist
 
     def is_dir(self, name):


### PR DESCRIPTION
Gallery detection fix for archives that zipfiles.namelist() method doesn't show folders for (issue 1).