### PR TITLE
Much easier file to use on linux

### DIFF
--- a/build_js.sh
+++ b/build_js.sh
@@ -1,0 +1,1 @@
+gksu ./build_js.py


### PR DESCRIPTION
Does it so you can just double click build_js.sh (or use a terminal), also automatically does a root prompt. This is easier instead of "sudo python3 build_js.py"

Needs a "./"able build_js.py.